### PR TITLE
Pull request for rotation not working

### DIFF
--- a/face_swap/face_renderer.cpp
+++ b/face_swap/face_renderer.cpp
@@ -230,7 +230,7 @@ namespace face_swap
         float ry = vecR.at<float>(1);
         float rz = vecR.at<float>(2);
         float angle = (float)sqrt(rx * rx + ry * ry + rz * rz);
-        if(abs(angle) > 1e-6f)
+        if(std::abs(angle) > 1e-6f)
             glRotatef(angle / CV_PI*180.0f, rx / angle, ry / angle, rz / angle);
 
         drawMesh();

--- a/iris_sfs/FaceServices2.cpp
+++ b/iris_sfs/FaceServices2.cpp
@@ -664,7 +664,7 @@ bool FaceServices2::estimatePoseExpr(cv::Mat colorIm, cv::Mat lms, cv::Mat alpha
 	landModel0 = festimator.getLM(shape,yaw);
 	std::vector<int> lmVisInd;
 	for (int i=0;i<60;i++){
-		if (i > 16 || abs(yaw) <= M_PI/10 || (yaw > M_PI/10 && i > 7) || (yaw < -M_PI/10 && i < 9))
+		if ((yaw > M_PI/10 && i > 7) || (yaw < -M_PI/10 && i < 9) || i > 16 || abs(yaw) <= M_PI/10)
 			lmVisInd.push_back(i);
 	}
 	cv::Mat tmpIm = colorIm/5;


### PR DESCRIPTION
It turns out that calling `abs` instead of `std::abs` refers to the `abs` in `stdlib.h`, which is a integer version.
So that the if clause will never pass through resulting in no rotation.

Also, I found that in calculating the rotation matrix, the if clause might be short-circuited.